### PR TITLE
Fix message auth user

### DIFF
--- a/app/Http/Controllers/MessageController.php
+++ b/app/Http/Controllers/MessageController.php
@@ -28,6 +28,7 @@ class MessageController extends Controller
         $message = new Message;
         $message->fill([
             'message' => $request->input('message'),
+            'user_uuid' => auth()->user()->uuid
         ]);
         $message->save();
 

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -27,7 +27,6 @@ class Message extends Model
         parent::boot();
 	    self::creating(function (Message $message) {
             $message->uuid = UUID::uuid7();
-            $message->user_uuid = Auth::id();
         });
 	}
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,11 +30,11 @@ Route::middleware(['auth'])->group(function () {
     Route::get('/user/{user_id}', [UserController::class, 'getProfile']);
     Route::put('/user/profile', [UserController::class, 'updateProfile']);
     Route::put('/user/password', [UserController::class, 'updatePassword']);
+    
+    Route::get('/timeline', [MessageController::class, 'index']);
+    Route::post('/message', [MessageController::class, 'create']);
+    Route::get('/message/{message_id}', [MessageController::class, 'show']);
+
+    Route::post('/message/{message_id}/like', [MessageController::class, 'like']);
+    Route::delete('/message/{message_id}/like', [MessageController::class, 'delete_like']);
 });
-
-Route::get('/timeline', [MessageController::class, 'index']);
-Route::post('/message', [MessageController::class, 'create']);
-Route::get('/message/{message_id}', [MessageController::class, 'show']);
-
-Route::post('/message/{message_id}/like', [MessageController::class, 'like']);
-Route::delete('/message/{message_id}/like', [MessageController::class, 'delete_like']);

--- a/tests/Feature/LikeTest.php
+++ b/tests/Feature/LikeTest.php
@@ -40,8 +40,6 @@ class LikeTest extends TestCase
         $this->user2->name = 'test user2';
         $this->user2->password = Hash::make('password');
         $this->user2->save();
-
-        Auth::login($this->user);
     }
 
     public function test_like_create()
@@ -50,16 +48,17 @@ class LikeTest extends TestCase
         $message = new Message;
         $message->fill([
             'message' => 'test message',
+            'user_uuid' => $this->user->uuid
         ]);
         $message->save();
 
         // like 登録API
         $message_uuid = $message['uuid'];
-        $response = $this->post("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user)->post("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_OK)->assertJson(['status' => Response::HTTP_OK]);
 
         // message のlike_countが正しく更新されているか
-        $message_response = $this->get("/api/message/${message_uuid}");
+        $message_response = $this->actingAs($this->user)->get("/api/message/${message_uuid}");
         $message_response->assertStatus(Response::HTTP_OK)->assertJson(fn (AssertableJson $json) =>
             $json->where('status', Response::HTTP_OK)
             ->has("data", 1, fn ($json) =>
@@ -82,23 +81,24 @@ class LikeTest extends TestCase
         $message = new Message;
         $message->fill([
             'message' => 'test message',
+            'user_uuid' => $this->user->uuid
         ]);
         $message->save();
 
         // like 登録API
         $message_uuid = $message['uuid'];
-        $response = $this->post("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user)->post("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_OK)->assertJson(['status' => Response::HTTP_OK]);
         $this->assertDatabaseHas('likes', ['user_uuid' => Auth::id(), 'message_uuid' => $message_uuid]);
 
         // like 削除API
         $message_uuid = $message['uuid'];
-        $response = $this->delete("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user)->delete("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_NO_CONTENT);
         $this->assertDatabaseMissing('likes', ['user_uuid' => Auth::id(), 'message_uuid' => $message_uuid]);
 
         // message のlike_count の確認
-        $message_response = $this->get("/api/message/${message_uuid}");
+        $message_response = $this->actingAs($this->user)->get("/api/message/${message_uuid}");
         $message_response->assertStatus(Response::HTTP_OK)->assertJson(fn (AssertableJson $json) =>
             $json->where('status', Response::HTTP_OK)
             ->has("data", 1, fn ($json) =>
@@ -118,16 +118,17 @@ class LikeTest extends TestCase
         $message = new Message;
         $message->fill([
             'message' => 'test message',
+            'user_uuid' => $this->user->uuid
         ]);
         $message->save();
 
         // like 登録API
         $message_uuid = $message['uuid'];
-        $response = $this->post("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user)->post("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_OK);
 
         $message_uuid = $message['uuid'];
-        $response = $this->post("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user)->post("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_OK);
         $this->assertDatabaseHas('likes', ['user_uuid' => Auth::id(), 'message_uuid' => $message_uuid]);
     }
@@ -138,12 +139,13 @@ class LikeTest extends TestCase
         $message = new Message;
         $message->fill([
             'message' => 'test message',
+            'user_uuid' => $this->user->uuid
         ]);
         $message->save();
 
         // like 削除API
         $message_uuid = $message['uuid'];
-        $response = $this->delete("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user)->delete("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_NO_CONTENT);
         $this->assertDatabaseMissing('likes', ['user_uuid' => Auth::id(), 'message_uuid' => $message_uuid]);
     }
@@ -154,26 +156,24 @@ class LikeTest extends TestCase
         $message = new Message;
         $message->fill([
             'message' => 'test message',
+            'user_uuid' => $this->user->uuid
         ]);
         $message->save();
 
         // like 登録API
         $message_uuid = $message['uuid'];
-        $response = $this->post("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user)->post("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_OK)->assertJson(['status' => Response::HTTP_OK]);
         $this->assertDatabaseHas('likes', ['user_uuid' => Auth::id(), 'message_uuid' => $message_uuid]);
 
-        // user 変更
-        Auth::login($this->user2);
-
         // like 登録API
         $message_uuid = $message['uuid'];
-        $response = $this->post("/api/message/${message_uuid}/like");
+        $response = $this->actingAs($this->user2)->post("/api/message/${message_uuid}/like");
         $response->assertStatus(Response::HTTP_OK)->assertJson(['status' => Response::HTTP_OK]);
         $this->assertDatabaseHas('likes', ['user_uuid' => Auth::id(), 'message_uuid' => $message_uuid]);
 
         // message のlike_count の確認
-        $message_response = $this->get("/api/message/${message_uuid}");
+        $message_response = $this->actingAs($this->user)->get("/api/message/${message_uuid}");
         $message_response->assertStatus(Response::HTTP_OK)->assertJson(fn (AssertableJson $json) =>
             $json->where('status', Response::HTTP_OK)
             ->has("data", 1, fn ($json) =>


### PR DESCRIPTION
**Pull Request**
close #38 

- [x] messageのbootからuser_uuidの作成をコントローラーに移動
- [x] Auth()::login()からactingAsへ変更
- [x] api.phpでmiddlewareを適用